### PR TITLE
Implement cross-platform P2P file exchange commands

### DIFF
--- a/cmds/list.go
+++ b/cmds/list.go
@@ -1,23 +1,17 @@
 package cmds
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+	"pulse/fn"
 )
 
-func ListCmd() *cobra.Command{
-
-var listgroup []string;
-		
+func ListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Protocols list",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("voici la liste des groupes %s", listgroup)
-	},
-}
-
-return cmd
-
+			fn.FnList()
+		},
+	}
+	return cmd
 }

--- a/cmds/post.go
+++ b/cmds/post.go
@@ -8,24 +8,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func PostCmd() *cobra.Command{
+func PostCmd() *cobra.Command {
 
 	var file string
 	var protocol string
 	var idFile string
-	
+
 	cmd := &cobra.Command{
 		Use:   "post",
 		Short: "Publish data to a protocol",
 		Run: func(cmd *cobra.Command, args []string) {
-		if protocol=="" || file == "" || idFile ==""  {
+			if protocol == "" || file == "" || idFile == "" {
 				fmt.Printf("You have to specify Protocol, File & idFile path")
 				os.Exit(1)
 			}
-			
-			fn.FnPost(protocol,file, idFile)
-			
-			
+
+			fmt.Println(fn.FnPost(protocol, file, idFile))
+
 		},
 	}
 

--- a/cmds/stop.go
+++ b/cmds/stop.go
@@ -2,28 +2,25 @@ package cmds
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
+	"pulse/fn"
 )
 
-func StopCmd() *cobra.Command{
-
-	var groupFileName string;
-
-	
+func StopCmd() *cobra.Command {
+	var group string
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop protocol listener",
 		Run: func(cmd *cobra.Command, args []string) {
-			if groupFileName == "" {
+			if group == "" {
 				fmt.Printf("Vous devez préciser le nom du groupe pour l'arrêter --name")
+				return
 			}
-			fmt.Printf("\n✅ Votre dépot a bien été enregistré à ce chemin : %s.\n\n", groupFileName)
+			if err := fn.FnStop(group); err != nil {
+				fmt.Println("error:", err)
+			}
 		},
 	}
-
-	cmd.Flags().StringVarP(&groupFileName, "name", "n", "", "Nom du groupe")
-
+	cmd.Flags().StringVarP(&group, "name", "n", "", "Nom du groupe")
 	return cmd
-
 }

--- a/fn/fncreate.go
+++ b/fn/fncreate.go
@@ -9,38 +9,35 @@ import (
 	"path/filepath"
 )
 
-
-
 func FnCreate(groupname string, relayAddr string, outdir string) string {
-	basedir:=`C:/pulse_test`
-	os.MkdirAll(basedir, 0o755); 
-	
+	basedir := baseDir()
 
-	if outdir == ""{ outdir=`./repo`}
-	os.MkdirAll(outdir,0o755)
-	
-	protocol:=Protocol{
+	if outdir == "" {
+		outdir = "./repo"
+	}
+	os.MkdirAll(outdir, 0o755)
+
+	protocol := Protocol{
 		Groupname: groupname,
-		Protocol: endpointProtocol() ,
+		Protocol:  endpointProtocol(),
 		RelayAddr: relayAddr,
-		As:as(32),
-	
+		As:        as(32),
 	}
 
-	dataProtocol,_:=json.MarshalIndent(protocol,"","  ")
-	os.WriteFile(filepath.Join(basedir,"Protocol_"+groupname+".json"),dataProtocol,0600)
-	
-	return fmt.Sprintf("\n🌐 Protocol_%s has been created with success in %s\n📂 A repository directory has been created at %s\n\n🔥 Congratulations, you’ve created an endpoint for exchanging data\n\n🌟 Your protocol %s is now a standalone API! Welcome to Web3! :)\n\n", groupname,basedir,outdir, groupname)
+	dataProtocol, _ := json.MarshalIndent(protocol, "", "  ")
+	os.WriteFile(filepath.Join(basedir, "Protocol_"+groupname+".json"), dataProtocol, 0o600)
+
+	return fmt.Sprintf("\n🌐 Protocol_%s has been created with success in %s\n📂 A repository directory has been created at %s\n\n🔥 Congratulations, you’ve created an endpoint for exchanging data\n\n🌟 Your protocol %s is now a standalone API! Welcome to Web3! :)\n\n", groupname, basedir, outdir, groupname)
 }
 
-func endpointProtocol() string{
-	protoID:=make([]byte,16)
+func endpointProtocol() string {
+	protoID := make([]byte, 16)
 	rand.Read(protoID)
-	return "/pulse/"+base64.RawURLEncoding.EncodeToString(protoID)+"/1.0"
+	return "/pulse/" + base64.RawURLEncoding.EncodeToString(protoID) + "/1.0"
 }
 
 func as(n int) string {
-	b:=make([]byte,n)
+	b := make([]byte, n)
 	rand.Read(b)
 	return base64.RawURLEncoding.EncodeToString(b)
 }

--- a/fn/fnid.go
+++ b/fn/fnid.go
@@ -13,58 +13,51 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-
 func AddPeerId(peerID []string) string {
-
-	basedir:=`C:/pulse_test/IDFile`
-	os.MkdirAll(basedir, 0o755); 
-
+	basedir := filepath.Join(baseDir(), "IDFile")
+	os.MkdirAll(basedir, 0o755)
 
 	idf := IDFile{
 		PeerId: peerID,
 	}
 
-	data,_:=json.MarshalIndent(idf," ", " ")
+	data, _ := json.MarshalIndent(idf, " ", " ")
 
-	name:=make([]byte,8)
+	name := make([]byte, 8)
 	rand.Read(name)
-	file:=base64.RawURLEncoding.EncodeToString(name)+"_GroupID.json"
-	
-	os.WriteFile(filepath.Join(basedir,file),data,0o755)
+	file := base64.RawURLEncoding.EncodeToString(name) + "_GroupID.json"
 
+	os.WriteFile(filepath.Join(basedir, file), data, 0o755)
 
-	path:=filepath.Join(basedir,file)
+	path := filepath.Join(basedir, file)
 	fmt.Printf("Your file has been created : %s\n", path)
 
-	return path 
-
+	return path
 }
 
 func Getid() string {
+	basedir := filepath.Join(baseDir(), "IDFile")
+	os.MkdirAll(basedir, 0o755)
 
-	basedir:=`C:/pulse_test/IDFile`
-	os.MkdirAll(basedir, 0o755); 
+	privkey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
+	id, _ := peer.IDFromPrivateKey(privkey)
+	raw, _ := lcrypto.MarshalPrivateKey(privkey)
 
-	privkey,_,_:=crypto.GenerateEd25519Key(rand.Reader)
-	id,_:=peer.IDFromPrivateKey(privkey)
-	raw,_:= lcrypto.MarshalPrivateKey(privkey)
-
-	peerid:=IdPeer{
+	peerid := IdPeer{
 		PeerId: id.String(),
-		Priv: base64.StdEncoding.EncodeToString(raw),
+		Priv:   base64.StdEncoding.EncodeToString(raw),
 	}
 
-	data,_:=json.MarshalIndent(peerid," ", " ")
+	data, _ := json.MarshalIndent(peerid, " ", " ")
 
-	name:=make([]byte,8)
+	name := make([]byte, 8)
 	rand.Read(name)
-	file:=base64.RawURLEncoding.EncodeToString(name)+"_PeerID.json"
-	
-	os.WriteFile(filepath.Join(basedir,file),data,0o755)
+	file := base64.RawURLEncoding.EncodeToString(name) + "_PeerID.json"
 
+	os.WriteFile(filepath.Join(basedir, file), data, 0o755)
 
-	path:=filepath.Join(basedir,file)
+	path := filepath.Join(basedir, file)
 	fmt.Printf("Your file has been created : %s\n", path)
 
-	return id.String()	
+	return id.String()
 }

--- a/fn/fnlist.go
+++ b/fn/fnlist.go
@@ -1,5 +1,24 @@
 package fn
 
-func FnList() {
+import (
+	"fmt"
+	"os"
+	"strings"
+)
 
+// FnList prints the currently active listening groups.
+func FnList() {
+	dir := receiversDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		fmt.Println("No active listeners")
+		return
+	}
+	fmt.Println("Active groups:")
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".keep") {
+			name := strings.TrimSuffix(e.Name(), ".keep")
+			fmt.Println(" -", name)
+		}
+	}
 }

--- a/fn/fnstop.go
+++ b/fn/fnstop.go
@@ -1,0 +1,17 @@
+package fn
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FnStop removes the keep file for the given group to stop its listener.
+func FnStop(group string) error {
+	file := filepath.Join(receiversDir(), sanitize(group)+".keep")
+	if err := os.Remove(file); err != nil {
+		return err
+	}
+	fmt.Println("🛑 Listener stopped for", group)
+	return nil
+}

--- a/fn/paths.go
+++ b/fn/paths.go
@@ -1,0 +1,32 @@
+package fn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// baseDir returns the root directory used by Pulse to store its files.
+func baseDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	dir := filepath.Join(home, ".pulse")
+	os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+// receiversDir returns the directory where active receivers are tracked.
+func receiversDir() string {
+	dir := filepath.Join(baseDir(), "receivers")
+	os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+// sanitize replaces path separators in a name to create safe file names.
+func sanitize(name string) string {
+	name = strings.ReplaceAll(name, string(filepath.Separator), "_")
+	name = strings.ReplaceAll(name, " ", "_")
+	return name
+}


### PR DESCRIPTION
## Summary
- add path utilities for storing protocol metadata in a cross-platform base directory
- enhance get/post workflow with keep files and graceful shutdown
- expose list and stop commands for managing active listeners

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c5d25407b483269180795fed425873